### PR TITLE
fix bug in stft

### DIFF
--- a/hear21passt/models/preprocess.py
+++ b/hear21passt/models/preprocess.py
@@ -54,7 +54,7 @@ class AugmentMelSTFT(nn.Module):
 
         x = nn.functional.conv1d(x.unsqueeze(1), self.preemphasis_coefficient).squeeze(1)
         x = torch.stft(x, self.n_fft, hop_length=self.hopsize, win_length=self.win_length,
-                       center=True, normalized=False, window=self.window)
+                       center=True, normalized=False, window=self.window, return_complex=False)
         x = (x ** 2).sum(dim=-1)  # power mag
         fmin = self.fmin + torch.randint(self.fmin_aug_range, (1,)).item()
         fmax = self.fmax + self.fmax_aug_range // 2 - torch.randint(self.fmax_aug_range, (1,)).item()


### PR DESCRIPTION
If return_complex is not provided in stft, an error will be raised.